### PR TITLE
Version links should now match English version of the docs.

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -142,12 +142,12 @@ html_context = {
     "github_version": "master", # Version
     "conf_py_path": "/source/", # Path in the checkout to the docs root
     "current_version": current_version,
-    "languages": ( ("English", "/clearlinux/latest"),
-                   ("简体中文 (Simplified Chinese)", "/clearlinux/latest/zh_CN")
+    "languages": ( ("English", "/clear-linux-documentation"),
+                   ("简体中文 (Simplified Chinese)", "/clear-linux-documentation/zh_CN")
                    #("Chinese", "/clearlinux/latest/zh_CN")
                  ),
-    "versions": ( ("latest", "/clearlinux/latest"),
-                  ("Future versions", "/clearlinux/latest"))
+    "versions": ( ("latest", "/clear-linux-documentation"),
+                  ("future versions","/clear-linux-documentation"))
                   #("L19.01", "/clearlinux/L19.01"))
 }
 


### PR DESCRIPTION
Hosting location and directory structure has changed. Version links need to match.

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>